### PR TITLE
 Trim code, better document fd ownership 

### DIFF
--- a/fds.go
+++ b/fds.go
@@ -98,6 +98,8 @@ func newFds(l log15.Logger, inherited map[fileName]*file) *Fds {
 // Listen returns a listener inherited from the parent process, or creates a
 // new one. It is expected that the caller will close the returned listener
 // once the Upgrader indicates draining is desired.
+// The arguments are passed to net.Listen, and their meaning is described
+// there.
 func (f *Fds) Listen(network, addr string) (net.Listener, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/parent.go
+++ b/parent.go
@@ -20,7 +20,6 @@ const (
 
 type parent struct {
 	wr          *net.UnixConn
-	exited      <-chan error
 	coordinator *coordinator
 	l           log15.Logger
 }
@@ -93,7 +92,7 @@ func newParent(l log15.Logger, osi osIface, coordinationDir string) (*coordinato
 			sockFiles[i].Fd(),
 		}
 	}
-	l.Info("got fds from old parent", "numfds", len(files))
+	l.Info("got fds from old parent", "files", files)
 
 	// now that we have the FDs from the old parent, we just need to tell it when we're ready and then we're done and happy!
 

--- a/upgrader.go
+++ b/upgrader.go
@@ -175,24 +175,12 @@ func (u *Upgrader) awaitUpgrade() error {
 
 		readyTimeout := time.After(u.upgradeTimeout)
 		select {
-		case err := <-nextParent.exitedC:
-			if err == nil {
-				return errors.Errorf("next parent %s exited", nextParent)
-			}
-			return errors.Wrapf(err, "next parent %s exited", nextParent)
-
 		case <-u.stopC:
 			return errors.New("terminating")
-
 		case <-readyTimeout:
 			return errors.Errorf("new parent %s timed out", nextParent)
+		case <-nextParent.readyC:
 
-		case file := <-nextParent.readyC:
-			// Save file in exitFd, so that it's only closed when the process
-			// exits. This signals to the new process that the old process
-			// has exited.
-			// TODO: is this a thing?
-			u.exitFd = neverCloseThisFile{file}
 			close(u.exitC)
 			return nil
 		}

--- a/upgrader.go
+++ b/upgrader.go
@@ -2,7 +2,6 @@ package tableroll
 
 import (
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -26,8 +25,7 @@ type Upgrader struct {
 	stopOnce   sync.Once
 	stopC      chan struct{}
 	upgradeSem chan struct{}
-	exitC      chan struct{}      // only close this if holding upgradeSem
-	exitFd     neverCloseThisFile // protected by upgradeSem
+	exitC      chan struct{} // only close this if holding upgradeSem
 
 	upgradeSock *net.UnixListener
 
@@ -101,7 +99,7 @@ func newUpgrader(os osIface, coordinationDir string, opts ...Option) (*Upgrader,
 	}
 	s.coord = coord
 	s.parent = parent
-	s.Fds = newFds(files)
+	s.Fds = newFds(s.l, files)
 
 	go func() {
 		for {
@@ -180,7 +178,7 @@ func (u *Upgrader) awaitUpgrade() error {
 		case <-readyTimeout:
 			return errors.Errorf("new parent %s timed out", nextParent)
 		case <-nextParent.readyC:
-
+			u.l.Info("next parent is ready, marking ourselves as up for exit")
 			close(u.exitC)
 			return nil
 		}
@@ -223,10 +221,8 @@ func (u *Upgrader) Stop() {
 		// Interrupt any running Upgrade(), and
 		// prevent new upgrade from happening.
 		close(u.stopC)
-		u.upgradeSock.Close()
-
-		// Make sure exitC is closed if no upgrade was running.
 		u.upgradeSem <- struct{}{}
+		u.upgradeSock.Close()
 		select {
 		case <-u.exitC:
 		default:
@@ -234,15 +230,7 @@ func (u *Upgrader) Stop() {
 		}
 		<-u.upgradeSem
 
+		u.l.Info("closing file descriptors")
 		u.Fds.closeUsed()
 	})
-}
-
-// This file must never be closed by the Go runtime, since its used by the
-// child to determine when the parent has died. It must only be closed
-// by the OS.
-// Hence we make sure that this file can't be garbage collected by referencing
-// it from an Upgrader.
-type neverCloseThisFile struct {
-	file *os.File
 }


### PR DESCRIPTION
This removes further unneeded code and more clearly documents the fact
that the upgrader does not close passed in listeners, and that it's
expected the caller deals with that itself.