### PR TITLE
docs: document fd handoff steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 tableroll is a graceful upgrade process for network services. It allows
 zero-downtime upgrades (such that the listening socket never drops a
-connection) between multiple go processes.
+connection) between multiple [Go](https://golang.org/) processes.
 
 It is inspired heavily by cloudflare's
 [tableflip](https://github.com/cloudflare/tableflip) library.
@@ -16,3 +16,79 @@ be managed by an external service manager, such as a systemd template unit.
 Instead of coordinating upgrades between a parent and child process, tableroll
 coordinates upgrades between a number of processes that agree on a well-known
 filesystem path ahead of time, and which all have access to that path.
+
+## Usage
+
+tableroll's usage is similar to [tableflip](https://github.com/cloudflare/tableflip)'s usage.
+
+In general, your process should do the following:
+
+1. Construct an upgrader using `tableroll.New`
+1. Create or add all managed listeners / connections / files via `upgrader.Fds`.
+1. Mark itself as ready to accept connections using `upgrader.Ready`
+1. Wait for a request to exit using the `upgrader.UpgradeComplete` channel
+1. Close all managed listeners and drain all connections (e.g. using `server.Shutdown` on `http.Server`)
+
+One example usage might be the following:
+
+### Usage Example
+
+The following example shows a simple usage of tableroll.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/ngrok/tableroll"
+)
+
+func main() {
+	logger := log15.New()
+	if err := os.MkdirAll("/tmp/testroll", 0700); err != nil {
+		log.Fatalf("can't create coordination dir: %v", err)
+	}
+	upg, err := tableroll.New("/tmp/testroll", tableroll.WithLogger(logger))
+	if err != nil {
+		panic(err)
+	}
+	ln, err := upg.Fds.Listen("tcp", "127.0.0.1:8080")
+	if err != nil {
+		log.Fatalf("can't listen: %v", err)
+	}
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(r http.ResponseWriter, req *http.Request) {
+			logger.Info("got http connection")
+			time.Sleep(10 * time.Second)
+			r.Write([]byte(fmt.Sprintf("hello from %v!\n", os.Getpid())))
+		}),
+	}
+	go server.Serve(ln)
+
+	if err := upg.Ready(); err != nil {
+		panic(err)
+	}
+	<-upg.UpgradeComplete()
+
+	time.AfterFunc(30*time.Second, func() {
+		os.Exit(1)
+	})
+
+	_ = server.Shutdown(context.Background())
+
+	logger.Info("server shutdown")
+}
+```
+
+When this program is run, it will listen on port `8080` for http connections.
+If you start another copy of it, the newer copy will take over. If you have
+pending http requests in-flight, they'll be handled by the old process before
+it shuts down.

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@
 // directory, and between those many processes, one is chosen to own all
 // shareable / upgradeable file descriptors.
 // Each upgrade uniquely involves two processes, and unix exclusive locks on
-// the filesystme coordinate that.
+// the filesystem ensure that.
 //
 // Each process under tableroll should be able to signal readiness, which will
 // indicate to tableroll that it is safe for previous processes to cease
@@ -16,5 +16,6 @@
 // binary is started independently, such as in a new container, not as a child
 // of the existing one. How a new upgrade is started is entirely out of scope
 // of this library. Both copies of the process must have access to the same
-// coordination directory, but other than that, it's fine.
+// coordination directory, but apart from that, there are no stringent
+// requirements.
 package tableroll

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,54 @@
+## Tableroll Design
+
+### File descriptor handoff protocol
+
+tableroll defines a custom protocol in order to coordinate taking ownership of a collection of file descriptors over a unix socket. It consists of the following notable filesystem paths:
+
+* The coordination directory &mdash; this directory, typically in
+  `/run/${programName}/tableroll`, is used to coordinate state between each
+  running process involved in the tableroll upgrade group.
+* The pid file &mdash; a `pid` file within the coordination directory is used
+  to indicate the current active holder of all file descriptors. A process will
+  write its own pid to that file after a handoff with the previous process
+  whose pid was in the pid file.
+* Coordination unix sockets &mdash; each process will also listen on a socket
+  within the coordination directory. This socket is the means by which a file
+  descriptor handoff may be initiated, and the medium over which file
+  descriptors will be passed. Each socket is named `${pid}.sock` within the
+  coordination directory.
+
+#### Handoff protocol
+
+The actual protocol always takes place between two processes. For the sake of
+example, let's assume the chosen coordination directory is
+`/run/example/tableroll`, and that two processes using that directory exist.
+These processes will be the "first" and the "second" processes, where the
+"first" process arbitrarily holds two open file descriptors that are marked
+passable, '127.0.0.1:80' and '127.0.0.1:443'.
+
+The handoff of these two FDs from "first" to "second" will look like the following:
+
+1. "second" begins listening on `/run/example/tableroll/${second_pid}.sock`.
+1. "second" takes an exclusive lock on the pid file, `/run/example/tableroll/pid`.
+1. "second" reads the value `${first_pid}` from the pid file.
+1. "second" opens a unix connection to `/run/example/tableroll/${first_pid}.sock`.
+1. "first" accepts the connection and writes the following data to it:
+    1. `70` &mdash; The length of the following message, as a 4 byte signed integer in big endian.
+    1. `[["listener","tcp","127.0.0.1:80"],["listener","tcp","127.0.0.1:443"]]` &mdash; A JSON encoding of the names of all file descriptors to expect
+    1. *file descriptors* &mdash; Both file descriptors mentioned in the previous
+       message, in the same order. These are written using unix's "sendmsg"
+       syscall.
+1. "second", after reading all the preceeding data, returns control to the
+   caller of this library temporarily. It is expected for the caller to do
+   necessary work to allow accepting connections on the transfered listening
+   sockets.  At this point, both "first" and "second" have functioning
+   listening sockets, "second" continues to hold the pid file lock, and
+   "second" still has a unix connection open to "first".
+1. "second" has its `upgrader.Ready()` method called, which results in the following:
+    1. The byte `42` is sent on the open unix connection to "first"
+    1. "second" writes its pid to the pid file.
+    1. "second" unlocks the exclusive lock it held on the pid file.
+    1. "second" closes the unix connection to "first".
+1. "first" reads `42` from the unix connection.
+1. "first" writes to the 'Exit' channel, indicating to the library user that
+   listeners should be closed and connections drained.


### PR DESCRIPTION
This is a start at having more useful documentation of this thing.

I do think understanding the expected file descriptor flow is useful, so it's worth capturing this.