### PR TITLE
fds: rework to be id based and allow removal; make store 'lockable' from mutation

### DIFF
--- a/dup_file_legacy.go
+++ b/dup_file_legacy.go
@@ -6,6 +6,6 @@ import (
 	"os"
 )
 
-func dupFile(fh *os.File, name fileName) (*file, error) {
+func dupFile(fh *os.File, name string) (*file, error) {
 	return dupFd(fh.Fd(), name)
 }

--- a/fds_test.go
+++ b/fds_test.go
@@ -1,6 +1,7 @@
 package tableroll
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestFdsListen(t *testing.T) {
+	ctx := context.Background()
 	addrs := [][2]string{
 		{"unix", ""},
 		{"tcp", "localhost:0"},
@@ -17,7 +19,7 @@ func TestFdsListen(t *testing.T) {
 	fds := newFds(l, nil)
 
 	for _, addr := range addrs {
-		ln, err := fds.Listen(addr[0], addr[1])
+		ln, err := fds.Listen(ctx, "1", nil, addr[0], addr[1])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,12 +56,12 @@ func TestFdsListener(t *testing.T) {
 	defer unix.Close()
 
 	parent := newFds(l, nil)
-	if err := parent.AddListener(addr.Network(), addr.String(), tcp); err != nil {
+	if _, err := parent.ListenWith("1", addr.Network(), addr.String(), func(_, _ string) (net.Listener, error) { return tcp, nil }); err != nil {
 		t.Fatal("Can't add listener:", err)
 	}
 	tcp.Close()
 
-	if err := parent.AddListener("unix", socketPath, unix.(Listener)); err != nil {
+	if _, err := parent.ListenWith("2", "unix", socketPath, func(_, _ string) (net.Listener, error) { return unix.(Listener), nil }); err != nil {
 		t.Fatal("Can't add listener:", err)
 	}
 	unix.Close()
@@ -69,7 +71,7 @@ func TestFdsListener(t *testing.T) {
 	}
 
 	child := newFds(l, parent.copy())
-	ln, err := child.Listener(addr.Network(), addr.String())
+	ln, err := child.Listener("1")
 	if err != nil {
 		t.Fatal("Can't get listener:", err)
 	}
@@ -78,29 +80,29 @@ func TestFdsListener(t *testing.T) {
 	}
 	ln.Close()
 
-	child.closeInherited()
+	child.Remove("2")
 	if _, err := os.Stat(socketPath); err == nil {
-		t.Error("closeInherited() did not unlink socketPath")
+		t.Error("Remove() did not unlink socketPath")
 	}
 }
 
 func TestFdsConn(t *testing.T) {
-	unix, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
-		Net:  "unixgram",
-		Name: "",
+	parent := newFds(l, nil)
+	unixConn, err := parent.DialWith("1", "unixgram", "", func(_, _ string) (net.Conn, error) {
+		return net.ListenUnixgram("unixgram", &net.UnixAddr{
+			Net:  "unixgram",
+			Name: "",
+		})
 	})
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	parent := newFds(l, nil)
-	if err := parent.AddConn("unixgram", "", unix); err != nil {
 		t.Fatal("Can't add conn:", err)
 	}
-	unix.Close()
+	unixConn.Close()
+	defer parent.Remove("1")
 
 	child := newFds(l, parent.copy())
-	conn, err := child.Conn("unixgram", "")
+	defer child.Remove("1")
+	conn, err := child.Conn("1")
 	if err != nil {
 		t.Fatal("Can't get conn:", err)
 	}
@@ -118,10 +120,13 @@ func TestFdsFile(t *testing.T) {
 	defer r.Close()
 
 	parent := newFds(l, nil)
-	if err := parent.AddFile("test", w); err != nil {
+	if _, err := parent.OpenFileWith("test", "test", func(_ string) (*os.File, error) {
+		return w, nil
+	}); err != nil {
 		t.Fatal("Can't add file:", err)
 	}
 	w.Close()
+	defer parent.Remove("test")
 
 	child := newFds(l, parent.copy())
 	file, err := child.File("test")

--- a/upgrader.go
+++ b/upgrader.go
@@ -25,7 +25,6 @@ type Upgrader struct {
 	coord       *coordinator
 	session     *upgradeSession
 	upgradeSock *net.UnixListener
-	readyOnce   sync.Once
 	stopOnce    sync.Once
 
 	stateLock sync.Mutex
@@ -208,10 +207,6 @@ func (u *Upgrader) Ready() error {
 	u.stateLock.Lock()
 	defer u.stateLock.Unlock()
 
-	u.readyOnce.Do(func() {
-		u.Fds.closeInherited()
-	})
-
 	if !u.session.hasOwner() {
 		// If we can't find a owner to request listeners from, then just assume we
 		// are the owner.
@@ -262,6 +257,6 @@ func (u *Upgrader) Stop() {
 		}
 
 		u.l.Info("closing file descriptors")
-		u.Fds.closeUsed()
+		u.Fds.closeFds()
 	})
 }

--- a/upgrader.go
+++ b/upgrader.go
@@ -167,6 +167,7 @@ func (u *Upgrader) handleUpgradeRequest(conn *net.UnixConn) {
 	}
 
 	u.l.Info("handling an upgrade request from peer")
+	u.Fds.lockMutations(ErrUpgradeInProgress)
 	// time to pass our FDs along
 	nextOwner, errC := passFdsToSibling(u.l, conn, u.Fds.copy())
 
@@ -184,16 +185,21 @@ func (u *Upgrader) handleUpgradeRequest(conn *net.UnixConn) {
 			// is desired.
 			// At this point, we can't really do anything but complain.
 			u.l.Error("unable to remain owner after upgrade failure", "err", err)
+			return
 		}
+		u.Fds.unlockMutations()
 	case <-readyTimeout.C:
 		u.l.Error("failed to pass file descriptors to next owner", "reason", "timeout")
 		if err := u.transitionTo(upgraderStateOwner); err != nil {
 			u.l.Error("unable to remain owner after upgrade timeout", "err", err)
+			return
 		}
+		u.Fds.unlockMutations()
 	case <-nextOwner.readyC:
 		u.l.Info("next owner is ready, marking ourselves as up for exit")
 		// ignore error, if we were 'Stopped' we can't transition, but we also
 		// don't care.
+		u.Fds.lockMutations(ErrUpgradeCompleted)
 		_ = u.transitionTo(upgraderStateDraining)
 		close(u.upgradeCompleteC)
 	}
@@ -247,6 +253,7 @@ func (u *Upgrader) UpgradeComplete() <-chan struct{} {
 func (u *Upgrader) Stop() {
 	u.mustTransitionTo(upgraderStateStopped)
 	u.stopOnce.Do(func() {
+		u.Fds.lockMutations(ErrUpgraderStopped)
 		// Interrupt any running Upgrade(), and
 		// prevent new upgrade from happening.
 		u.upgradeSock.Close()

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -91,7 +91,7 @@ func createTestServer(t *testing.T, pid int, coordDir string, requests chan<- st
 		t.Fatalf("error creating upgrader: %v", err)
 	}
 
-	listen, err := upg.Fds.Listen("tcp", "127.0.0.1:0")
+	listen, err := upg.Fds.Listen(context.Background(), "testListen", nil, "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("unable to listen: %v", err)
 	}

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -3,9 +3,11 @@ package tableroll
 import (
 	"context"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/inconshreveable/log15"
@@ -13,12 +15,19 @@ import (
 
 var l = log15.New()
 
-func TestUpgradeHandoff(t *testing.T) {
-	coordDir, err := ioutil.TempDir("", "tableroll_test")
+func tmpDir() (string, func()) {
+	dir, err := ioutil.TempDir("", "tableroll_test")
 	if err != nil {
 		panic(err)
 	}
-	defer os.RemoveAll(coordDir)
+	return dir, func() {
+		os.RemoveAll(dir)
+	}
+}
+
+func TestUpgradeHandoff(t *testing.T) {
+	coordDir, cleanup := tmpDir()
+	defer cleanup()
 
 	server1Msgs, server2Msgs := make(chan string), make(chan string)
 	server1Reqs, server2Reqs := make(chan struct{}), make(chan struct{})
@@ -62,6 +71,66 @@ func TestUpgradeHandoff(t *testing.T) {
 	<-msg2Response
 }
 
+func TestMutableUpgrading(t *testing.T) {
+	coordDir, cleanup := tmpDir()
+	defer cleanup()
+
+	upg1, err := newUpgrader(context.Background(), mockOS{pid: 1}, coordDir, WithLogger(l))
+	if err != nil {
+		t.Fatalf("error creating upgrader: %v", err)
+	}
+	if err := upg1.Ready(); err != nil {
+		t.Fatalf("error marking ready: %v", err)
+	}
+
+	upgradeDone := make(chan struct{})
+	expectedFis := map[string]*os.File{}
+	// Mutably add a bunch of fds to the store at random, make sure that all the ones that were added without error are inherited
+	go func() {
+		var err error
+		var fi *os.File
+		for err != ErrUpgradeCompleted {
+			// add 2/3 of the time, remove 1/3 of the time, pool of 1000 ids
+			id := strconv.Itoa(rand.Intn(1000))
+			if expectedFis[id] != nil {
+				if err = upg1.Fds.Remove(id); err == nil {
+					delete(expectedFis, id)
+				} else if err != ErrUpgradeInProgress && err != ErrUpgradeCompleted {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if fi, err = upg1.Fds.OpenFileWith(id, id, memoryOpenFile); err == nil {
+					expectedFis[id] = fi
+				} else if err != ErrUpgradeInProgress && err != ErrUpgradeCompleted {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		}
+		close(upgradeDone)
+	}()
+
+	upg2, err := newUpgrader(context.Background(), mockOS{pid: 2}, coordDir, WithLogger(l))
+	if err != nil {
+		t.Fatalf("error creating upgrader: %v", err)
+	}
+	if err := upg2.Ready(); err != nil {
+		t.Fatalf("error marking ready: %v", err)
+	}
+
+	// we expect that upg1 should have gotten a terminal error and we should have
+	// got the full set of ids it thinks it stored
+	<-upgradeDone
+
+	for id, expectedFi := range expectedFis {
+		if fi, err := upg2.Fds.File(id); fi != fi || err != nil {
+			t.Errorf("expected upg2 to have file for %v of %#v, but had file %#v, err %v", id, expectedFi, fi, err)
+		}
+	}
+
+	upg1.Stop()
+	upg2.Stop()
+}
+
 func assertResp(t *testing.T, url string, c *http.Client, expected string) {
 	resp, err := c.Get(url)
 	if err != nil {
@@ -101,4 +170,12 @@ func createTestServer(t *testing.T, pid int, coordDir string, requests chan<- st
 		t.Fatalf("unable to mark self as ready: %v", err)
 	}
 	return upg, server
+}
+
+func memoryOpenFile(name string) (*os.File, error) {
+	_, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	return w, nil
 }


### PR DESCRIPTION
This does a complete rework of the file descriptor store. It is not
backwards compatible with previous versions, and since there have been
no releases / users of tableroll yet, it's a hard breaking change with
no effort made to provide any migration path.

This also changes tableroll's "Fds" api to be entirely based on unique
identifiers for each listener.

Every way to add a fd to the store now requires the use of an ID, and
only the ID is used for retreiving said fds.

The idea of "inherited and used" file descriptors has also vanished. If
a program wishes to remove a file descriptor before, it would simply
avoid using it (e.g. a program that used to listen on :8080 and :8081
would simply no longer listen on :8081 after an upgrade, and that fd
would vanish).
After this change, all file descriptors are considered necessary if not
explicitly removed. To remove a now-unused listener after upgrade, the
'Remove' api must be called with the id after the upgrader is
constructed.

In addition to the focus on ids, this also attempts to allow better
locking support in the api through serializing all file descriptor
changes, and through encouraging users to create new listeners by
passing in a function which will have its execution guarded by a lock.

This paves the way for a world in which fds can be more easily mutated
over time, and where the draining state of an upgrader prevents new
listeners from being constructed.