### PR TITLE
fds: associate original files with an fd

### DIFF
--- a/fds.go
+++ b/fds.go
@@ -95,8 +95,12 @@ type fd struct {
 	Addr    string `json:"addr,omitEmpty"`
 }
 
-func (f *fd) associateFile(name string, file *os.File) {
-	f.file = newFile(file.Fd(), name)
+func (f *fd) associateFile(name string, osFile *os.File) {
+	f.file = &file{
+		osFile,
+		osFile.Fd(),
+	}
+	f.Name = name
 }
 
 func (f *fd) String() string {


### PR DESCRIPTION
This is required to avoid the gc closing files we received over the
upgrade socket.