### PR TITLE
upgrader: check for context cancels more carefully

### DIFF
--- a/transfer_owner.go
+++ b/transfer_owner.go
@@ -72,6 +72,13 @@ func (s *upgradeSession) getFiles(ctx context.Context) (map[string]*fd, error) {
 		select {
 		case <-functionEnd:
 		case <-ctx.Done():
+			// double check the function hasn't already returned, if it has then the
+			// session's out of our hands already.
+			select {
+			case <-functionEnd:
+				return
+			default:
+			}
 			// if there was a context error, close the socket to cause any pending reads/writes to fail
 			s.Close()
 		}


### PR DESCRIPTION
The included test failed infrequently before this change due to the go
scheduler not necessarily scheduling our 'select', and then randomly
picking the 'ctx' channel.

This change makes our API work as intended in the case shown in the
test.