### PR TITLE
upgrade_session: ignore close errors

### DIFF
--- a/transfer_owner.go
+++ b/transfer_owner.go
@@ -156,12 +156,9 @@ func (s *upgradeSession) Close() error {
 	var err error
 	s.closeOnce.Do(func() {
 		if s.wr != nil {
-			err = s.wr.Close()
+			s.wr.Close()
 		}
-		if coordErr := s.coordinator.Unlock(); coordErr != nil {
-			// unlock errors trump close errors arbitrarily
-			err = coordErr
-		}
+		err = s.coordinator.Unlock()
 	})
 	return err
 }


### PR DESCRIPTION
It's expected the other end of the unix socket might have already hung
up, just ignore the error.