### PR TITLE
Only transfer one fd at a time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,14 @@
 module github.com/ngrok/tableroll
 
 require (
-	github.com/ftrvxmtrx/fd v0.0.0-20150925145434-c6d800382fff
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/opencontainers/runc v1.0.0-rc6
 	github.com/pkg/errors v0.8.1
 	github.com/rkt/rkt v1.30.0
 	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect
+	k8s.io/utils v0.0.0-20190221042446-c2654d5206da
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/ftrvxmtrx/fd v0.0.0-20150925145434-c6d800382fff h1:zk1wwii7uXmI0znwU+lqg+wFL9G5+vm5I+9rv2let60=
-github.com/ftrvxmtrx/fd v0.0.0-20150925145434-c6d800382fff/go.mod h1:yUhRXHewUVJ1k89wHKP68xfzk7kwXUx/DV1nx4EBMbw=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -10,9 +8,13 @@ github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRU
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/opencontainers/runc v1.0.0-rc6 h1:7AoN22rYxxkmsJS48wFaziH/n0OvrZVqL/TglgHKbKQ=
+github.com/opencontainers/runc v1.0.0-rc6/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rkt/rkt v1.30.0 h1:ZI5RQtSibfjicSttV/HLiHuWreYClEJA2Or5XKAdJb0=
 github.com/rkt/rkt v1.30.0/go.mod h1:V5VwmwHe6x1kflB4uXl1XJwXTgRISEMt2lZE6m6lXd0=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+k8s.io/utils v0.0.0-20190221042446-c2654d5206da h1:ElyM7RPonbKnQqOcw7dG2IK5uvQQn3b/WPHqD5mBvP4=
+k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=

--- a/upgrader.go
+++ b/upgrader.go
@@ -253,8 +253,6 @@ func (u *Upgrader) UpgradeComplete() <-chan struct{} {
 
 // Stop prevents any more upgrades from happening, and closes
 // the upgrade complete channel.
-// It also closes any file descriptors in Fds which were inherited but are
-// unused.
 func (u *Upgrader) Stop() {
 	u.mustTransitionTo(upgraderStateStopped)
 	if u.session != nil {
@@ -270,7 +268,5 @@ func (u *Upgrader) Stop() {
 		default:
 			close(u.upgradeCompleteC)
 		}
-		u.l.Info("closing file descriptors")
-		u.Fds.closeFds()
 	})
 }


### PR DESCRIPTION
The previous code would pass all file descriptors as auxiliary data in a
single cmsg. This, it turns out, very easily hits limits on the size of
cmsg aux data. In practice, this happened at around 300 to 500 listening
sockets.

This changes the code to only pass one at a time, adds a test that
failed before, and for good measure switches to a different upstream
library for doing the transfer.