### PR TITLE
fix compilation on Darwin

### DIFF
--- a/fds.go
+++ b/fds.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -485,7 +486,7 @@ func dupConn(conn syscall.Conn, name string) (*file, error) {
 }
 
 func dupFd(fd uintptr, name string) (*file, error) {
-	dupfd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_DUPFD_CLOEXEC, 0)
+	dupfd, _, errno := unix.Syscall(unix.SYS_FCNTL, fd, unix.F_DUPFD_CLOEXEC, 0)
 	if errno != 0 {
 		return nil, errors.Wrap(errno, "can't dup fd using fcntl")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,13 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/opencontainers/runc v1.0.0-rc6
+	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.8.1
 	github.com/rkt/rkt v1.30.0
-	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect
+	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e
 	k8s.io/utils v0.0.0-20190221042446-c2654d5206da
 )
+
+replace github.com/opencontainers/runc => github.com/kevinburke/runc v1.0.0-rc8.0.20190502155026-3ec7f94c7effb7b2ca325eeb4a775646d44238a7
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,12 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec h1:CGkYB1Q7DSsH/ku+to+foV4agt2F2miquaLUgF6L178=
 github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
+github.com/kevinburke/runc v1.0.0-rc8.0.20190502155026-3ec7f94c7effb7b2ca325eeb4a775646d44238a7 h1:19pLvcgWD2wAbZf2Ed6eydx48zxhsVhMXq6U1JGcHsI=
+github.com/kevinburke/runc v1.0.0-rc8.0.20190502155026-3ec7f94c7effb7b2ca325eeb4a775646d44238a7/go.mod h1:sVh4Xk3lGT1VD6ZEtyxDZoz+OGWDx7iWHsQtjVYNQYc=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/opencontainers/runc v1.0.0-rc6 h1:7AoN22rYxxkmsJS48wFaziH/n0OvrZVqL/TglgHKbKQ=
-github.com/opencontainers/runc v1.0.0-rc6/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rkt/rkt v1.30.0 h1:ZI5RQtSibfjicSttV/HLiHuWreYClEJA2Or5XKAdJb0=


### PR DESCRIPTION
This package does not compile on Darwin because a file in
runc/libcontainer/utils contains a constant that does not exist on
Darwin builds.

The code out of that package that we need has no problems compiling on
Darwin however so pull it into a shim and load it from there.

If opencontainers/runc#2048 is resolved maybe we can re-import the
other package.