### PR TITLE
 Implement v1 protocol ready handshake 

### DIFF
--- a/coordination.go
+++ b/coordination.go
@@ -158,6 +158,7 @@ func (c *coordinator) ConnectOwner(ctx context.Context) (*net.UnixConn, error) {
 		c.l.Warn("found living pid in coordination dir, but it wasn't listening for us", "pid", ppid, "dialErr", err)
 		return nil, errNoOwner
 	}
+
 	return conn.(*net.UnixConn), nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,12 @@
 module github.com/ngrok/tableroll
 
 require (
-	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/euank/tableroll v1.0.1-0.20190509205925-1c7855724129
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
-	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.8.1
 	github.com/rkt/rkt v1.30.0
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e
 	k8s.io/utils v0.0.0-20190221042446-c2654d5206da
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/euank/tableroll v1.0.1-0.20190509205925-1c7855724129 h1:oDXWZeVpyOpwiT/4qTGcG1kLEYMIzEhQcobFJNk/q6Y=
+github.com/euank/tableroll v1.0.1-0.20190509205925-1c7855724129/go.mod h1:KQ+1DFOz7fXvymPM5QN0korxL5Ai0t3xNG/vRWP42C0=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -12,8 +16,13 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rkt/rkt v1.30.0 h1:ZI5RQtSibfjicSttV/HLiHuWreYClEJA2Or5XKAdJb0=
 github.com/rkt/rkt v1.30.0/go.mod h1:V5VwmwHe6x1kflB4uXl1XJwXTgRISEMt2lZE6m6lXd0=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da h1:ElyM7RPonbKnQqOcw7dG2IK5uvQQn3b/WPHqD5mBvP4=

--- a/internal/proto/consts.go
+++ b/internal/proto/consts.go
@@ -1,9 +1,9 @@
 package proto
 
 const (
-	// ProtoVersion is the latest version of the protocol. It is implicitly 0 for
+	// Version is the latest version of the protocol. It is implicitly 0 for
 	// clients that didn't yet have a protocol version
-	ProtoVersion = 1
+	Version = 1
 	// V0NotifyReady is the value sent at the end in the v0 protocol to indicate
 	// readyness
 	V0NotifyReady = 42

--- a/internal/proto/consts.go
+++ b/internal/proto/consts.go
@@ -4,6 +4,7 @@ const (
 	// Version is the latest version of the protocol. It is implicitly 0 for
 	// clients that didn't yet have a protocol version
 	Version = 1
+
 	// V0NotifyReady is the value sent at the end in the v0 protocol to indicate
 	// readyness
 	V0NotifyReady = 42

--- a/internal/proto/consts.go
+++ b/internal/proto/consts.go
@@ -1,0 +1,16 @@
+package proto
+
+const (
+	// ProtoVersion is the latest version of the protocol. It is implicitly 0 for
+	// clients that didn't yet have a protocol version
+	ProtoVersion = 1
+	// V0NotifyReady is the value sent at the end in the v0 protocol to indicate
+	// readyness
+	V0NotifyReady = 42
+
+	// V1StartReadyHandshake is at the start of a v1 handshake
+	V1StartReadyHandshake = 0x42
+
+	// V1MessageSteppingDown is the message the old process sends in the handshake
+	V1MessageSteppingDown = "stepping down"
+)

--- a/internal/proto/doc.go
+++ b/internal/proto/doc.go
@@ -20,13 +20,17 @@
 // O sends 'Message{Msg: V1MessageSteppingDown}' to N
 // O closes the connection
 //
-// There is one failure mode of interest here.
+// There are two failure modes of interest here.
 // 1. O sends 'SteppingDown' but 'N' doesn't read it.
+// 2. O gets an error sending 'SteppingDown' and is unsure if 'N' received it.
 //
 // In the case of 1. the failure mode is that there is now no owner. The
 // expected behavior is that 'N', if it fails to complete the handshake, will
 // return an error from 'Ready()' and exit, and will then restart and get
 // succeed since there will now be no owner.
+// In the case of 2, O must assume that the message sent successfully and
+// actually step down. This again leaves us with 0 owners in the failure mode,
+// which is what we want.
 // All other cases should result in O remaining the owner, or the ownership
 // transfer completing successfully.
 package proto

--- a/internal/proto/doc.go
+++ b/internal/proto/doc.go
@@ -6,7 +6,7 @@
 // The v1 protocol exists because the v0 protocol allows for a new process to
 // think it had notified the previous owner it was ready, even if the new owner
 // never read that byte.
-// The primary reaon this is possible is because the protocol is over a stream
+// The primary reason this is possible is because the protocol is over a stream
 // oriented unix socket, not a unix dgram socket.
 // In order to fix this issue, the v1 protocol includes a more complete
 // 'upgrade complete' handshake which ensures both processes actively signal
@@ -24,13 +24,13 @@
 // 1. O sends 'SteppingDown' but 'N' doesn't read it.
 // 2. O gets an error sending 'SteppingDown' and is unsure if 'N' received it.
 //
-// In the case of 1. the failure mode is that there is now no owner. The
+// In the case of 1. the failure mode is that there are now no owners. The
 // expected behavior is that 'N', if it fails to complete the handshake, will
 // return an error from 'Ready()' and exit, and will then restart and get
 // succeed since there will now be no owner.
 // In the case of 2, O must assume that the message sent successfully and
-// actually step down. This again leaves us with 0 owners in the failure mode,
-// which is what we want.
+// actually step down. This again leaves us with zero owners in the failure
+// mode, which is what we want.
 // All other cases should result in O remaining the owner, or the ownership
 // transfer completing successfully.
 package proto

--- a/internal/proto/doc.go
+++ b/internal/proto/doc.go
@@ -1,0 +1,32 @@
+// Package proto encapsulates the types used to communicate between multiple
+// tableroll processes at various versions, as well as the functions for
+// reading and writing this data off the wire.
+//
+// Currently, there are two protocol versions: v0 and v1.
+// The v1 protocol exists because the v0 protocol allows for a new process to
+// think it had notified the previous owner it was ready, even if the new owner
+// never read that byte.
+// The primary reaon this is possible is because the protocol is over a stream
+// oriented unix socket, not a unix dgram socket.
+// In order to fix this issue, the v1 protocol includes a more complete
+// 'upgrade complete' handshake which ensures both processes actively signal
+// intent for the new process to take over.
+//
+// The v1 ready handshake between N, a new process which is attempting to
+// become an owner, and O, the current owner / old process, is the following:
+//
+// N sends 'V1StartReadyHandshake' to O
+// N sends 'VersionInformation{Version: 1}' to O
+// O sends 'Message{Msg: V1MessageSteppingDown}' to N
+// O closes the connection
+//
+// There is one failure mode of interest here.
+// 1. O sends 'SteppingDown' but 'N' doesn't read it.
+//
+// In the case of 1. the failure mode is that there is now no owner. The
+// expected behavior is that 'N', if it fails to complete the handshake, will
+// return an error from 'Ready()' and exit, and will then restart and get
+// succeed since there will now be no owner.
+// All other cases should result in O remaining the owner, or the ownership
+// transfer completing successfully.
+package proto

--- a/internal/proto/encode.go
+++ b/internal/proto/encode.go
@@ -29,9 +29,6 @@ func WriteVersionedJSONBlob(dst io.Writer, obj interface{}, version uint32) erro
 	if err := binary.Write(&jsonBlobLenBuf, binary.BigEndian, int32(jsonBlob.Len())); err != nil {
 		panic(fmt.Errorf("could not binary encode an int32: %v", err))
 	}
-	if jsonBlobLenBuf.Len() != 4 {
-		panic(fmt.Errorf("int32 should be 4 bytes, not: %+v", jsonBlobLenBuf))
-	}
 
 	// Length-prefixed json blob
 	if _, err := dst.Write(jsonBlobLenBuf.Bytes()); err != nil {

--- a/internal/proto/encode.go
+++ b/internal/proto/encode.go
@@ -1,0 +1,89 @@
+package proto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// WriteVersionedJSONBlob writes a JSON blob to the given writer. It expects
+// the blob to be read using 'ReadVersionedJSONBlob'.
+// A version is included via a v0 compatible hack since v0 did not include the
+// version. Specifically, the version is encoded as whitespace prefixing the
+// json data.
+func WriteVersionedJSONBlob(dst io.Writer, obj interface{}, version uint32) error {
+	versionPrefix := encodeVersion(version)
+
+	var jsonBlob bytes.Buffer
+	jsonBlob.Write(versionPrefix)
+	enc := json.NewEncoder(&jsonBlob)
+	if err := enc.Encode(obj); err != nil {
+		return err
+	}
+
+	var jsonBlobLenBuf bytes.Buffer
+	if err := binary.Write(&jsonBlobLenBuf, binary.BigEndian, int32(jsonBlob.Len())); err != nil {
+		panic(fmt.Errorf("could not binary encode an int32: %v", err))
+	}
+	if jsonBlobLenBuf.Len() != 4 {
+		panic(fmt.Errorf("int32 should be 4 bytes, not: %+v", jsonBlobLenBuf))
+	}
+
+	// Length-prefixed json blob
+	if _, err := dst.Write(jsonBlobLenBuf.Bytes()); err != nil {
+		return fmt.Errorf("could not write json length: %v", err)
+	}
+	if _, err := dst.Write(jsonBlob.Bytes()); err != nil {
+		return fmt.Errorf("could not write json: %v", err)
+	}
+	return nil
+}
+
+// WriteJSONBlob writes a length-prefixed json blob.
+func WriteJSONBlob(dst io.Writer, obj interface{}) error {
+	return WriteVersionedJSONBlob(dst, obj, 0)
+}
+
+// ReadVersionedJSONBlob reads a JSON blob from the given writer. If the blob
+// was written with WriteVersionedJSONBlob, it determines the version and
+// returns it.
+func ReadVersionedJSONBlob(src io.Reader, obj interface{}) (uint32, error) {
+	var jsonLen int32
+	if err := binary.Read(src, binary.BigEndian, &jsonLen); err != nil {
+		return 0, errors.Wrap(err, "protocol error: could not read length of json")
+	}
+
+	// don't decode directly from src, but rathre go through a buffer, because
+	// `json.Decode` will attempt to use a buffered reader which can accidentally
+	// lose fd's being sent across a socket.
+	data := make([]byte, jsonLen)
+	if n, err := io.ReadFull(src, data); err != nil || n != int(jsonLen) {
+		return 0, errors.Wrapf(err, "unable to read expected meta json length (expected %v, got (%v, %v))", jsonLen, n, err)
+	}
+	var prefix []byte
+	for i := 0; i < len(data); i++ {
+		if !isJSONIgnorableWhitespace(data[i]) {
+			prefix = data[0:i]
+			break
+		}
+	}
+	version, err := decodeVersion(prefix)
+	if err != nil {
+		return 0, errors.Wrapf(err, "could not determine version from prefix")
+	}
+
+	if err := json.Unmarshal(data, obj); err != nil {
+		return 0, errors.Wrap(err, "can't decode names from owner process")
+	}
+	return version, nil
+}
+
+// ReadJSONBlob reads a length-prefixed json blob written by WriteJSONBlob.
+func ReadJSONBlob(src io.Reader, obj interface{}) error {
+	_, err := ReadVersionedJSONBlob(src, obj)
+	return err
+}

--- a/internal/proto/encode.go
+++ b/internal/proto/encode.go
@@ -20,8 +20,7 @@ func WriteVersionedJSONBlob(dst io.Writer, obj interface{}, version uint32) erro
 
 	var jsonBlob bytes.Buffer
 	jsonBlob.Write(versionPrefix)
-	enc := json.NewEncoder(&jsonBlob)
-	if err := enc.Encode(obj); err != nil {
+	if err := json.NewEncoder(&jsonBlob).Encode(obj); err != nil {
 		return err
 	}
 
@@ -54,7 +53,7 @@ func ReadVersionedJSONBlob(src io.Reader, obj interface{}) (uint32, error) {
 		return 0, errors.Wrap(err, "protocol error: could not read length of json")
 	}
 
-	// don't decode directly from src, but rathre go through a buffer, because
+	// don't decode directly from src, but rather go through a buffer, because
 	// `json.Decode` will attempt to use a buffered reader which can accidentally
 	// lose fd's being sent across a socket.
 	data := make([]byte, jsonLen)

--- a/internal/proto/encode_version.go
+++ b/internal/proto/encode_version.go
@@ -1,0 +1,66 @@
+package proto
+
+import "fmt"
+
+// encodeVersion encodes a given uint32 as a json-ignorable sequence of whitespace
+func encodeVersion(version uint32) []byte {
+	result := []byte{}
+	for version > 0 {
+		nibble := version % 16
+		version = version >> 4
+
+		crumb1 := byte(nibble & 0x3)
+		crumb2 := byte(nibble >> 2)
+		result = append(result, []byte{encodeCrumb(crumb1), encodeCrumb(crumb2)}...) //, result...)
+	}
+	return result
+}
+
+// decodeVersion decodes a version from a json-ignorable sequence of whitespace
+func decodeVersion(data []byte) (uint32, error) {
+	var version uint32
+	for i := len(data) - 1; i >= 0; i-- {
+		crumb, err := decodeCrumb(data[i])
+		if err != nil {
+			return 0, err
+		}
+		version = version << 2
+		version += uint32(crumb)
+	}
+	return version, nil
+}
+
+// encodeCrumb encodes a crumb (2 bits, half a nibble) into a json-ignorable
+// whitespace character.
+func encodeCrumb(crumb byte) byte {
+	switch crumb {
+	case 0:
+		return ' '
+	case 1:
+		return '\t'
+	case 2:
+		return '\r'
+	case 3:
+		return '\n'
+	}
+	panic(fmt.Sprintf("byePair was not actually a pair of bytes: %x", crumb))
+}
+
+// decodeCrumb is the inverse operation of encodeCrumb.
+func decodeCrumb(char byte) (byte, error) {
+	switch char {
+	case ' ':
+		return 0, nil
+	case '\t':
+		return 1, nil
+	case '\r':
+		return 2, nil
+	case '\n':
+		return 3, nil
+	}
+	return 0, fmt.Errorf("char was not a whitespace encoding of a bytepair: %x", char)
+}
+
+func isJSONIgnorableWhitespace(char byte) bool {
+	return char == ' ' || char == '\t' || char == '\r' || char == '\n'
+}

--- a/internal/proto/encode_version.go
+++ b/internal/proto/encode_version.go
@@ -2,6 +2,11 @@ package proto
 
 import "fmt"
 
+// This file implements a way to encode and decode a uint32 as json-ignorable
+// whitespace. Since JSON allows 4 whitespace characters that will be ignored,
+// we can encode 2 bits per whitespace character. This file implements that
+// encoding.
+
 // encodeVersion encodes a given uint32 as a json-ignorable sequence of whitespace
 func encodeVersion(version uint32) []byte {
 	result := []byte{}

--- a/internal/proto/encode_version.go
+++ b/internal/proto/encode_version.go
@@ -48,7 +48,7 @@ func encodeCrumb(crumb byte) byte {
 	case 3:
 		return '\n'
 	}
-	panic(fmt.Sprintf("byePair was not actually a pair of bytes: %x", crumb))
+	panic(fmt.Sprintf("crumb was not actually a pair of bytes: %x", crumb))
 }
 
 // decodeCrumb is the inverse operation of encodeCrumb.
@@ -63,7 +63,7 @@ func decodeCrumb(char byte) (byte, error) {
 	case '\n':
 		return 3, nil
 	}
-	return 0, fmt.Errorf("char was not a whitespace encoding of a bytepair: %x", char)
+	return 0, fmt.Errorf("char was not a whitespace encoding of a crumb: %x", char)
 }
 
 func isJSONIgnorableWhitespace(char byte) bool {

--- a/internal/proto/encode_version_test.go
+++ b/internal/proto/encode_version_test.go
@@ -1,0 +1,42 @@
+package proto
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestVersionEncodeDecode(t *testing.T) {
+	// test the first 10k versions are both unique and roundtrip
+	unique := map[string]bool{}
+	for i := uint32(0); i < 10000; i++ {
+		val := encodeVersion(i)
+		if unique[string(val)] {
+			t.Errorf("version %v did not uniquely encode", i)
+		}
+		decoded, err := decodeVersion(val)
+		if err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+		if decoded != i {
+			t.Errorf("roundtrip error: %v(%q) != %v", i, val, decoded)
+		}
+	}
+}
+
+func TestQuickcheckVersionEncodeDecode(t *testing.T) {
+	if err := quick.Check(func(v uint32) bool {
+		val := encodeVersion(v)
+		decoded, err := decodeVersion(val)
+		if err != nil {
+			t.Fatalf("decode error: %v", err)
+			return false
+		}
+		if decoded != v {
+			t.Errorf("roundtrip error: %v(%q) != %v", v, val, decoded)
+			return false
+		}
+		return true
+	}, &quick.Config{}); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/proto/encode_version_test.go
+++ b/internal/proto/encode_version_test.go
@@ -13,6 +13,7 @@ func TestVersionEncodeDecode(t *testing.T) {
 		if unique[string(val)] {
 			t.Errorf("version %v did not uniquely encode", i)
 		}
+		unique[string(val)] = true
 		decoded, err := decodeVersion(val)
 		if err != nil {
 			t.Fatalf("decode error: %v", err)

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -1,0 +1,11 @@
+package proto
+
+// VersionInformation communicates the protocol version this process supports.
+// Added in v1
+type VersionInformation struct {
+	Version int32 `json:"version"`
+}
+
+type Message struct {
+	Msg string `json:"msg"`
+}

--- a/sibling.go
+++ b/sibling.go
@@ -1,14 +1,12 @@
 package tableroll
 
 import (
-	"bytes"
-	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 
 	"github.com/inconshreveable/log15"
+	"github.com/ngrok/tableroll/internal/proto"
 	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/pkg/errors"
 )
@@ -19,41 +17,32 @@ type sibling struct {
 	l      log15.Logger
 }
 
-func (c *sibling) String() string {
-	return c.conn.RemoteAddr().String()
+func newSibling(l log15.Logger, conn *net.UnixConn) *sibling {
+	return &sibling{
+		conn: conn,
+		l:    l,
+	}
+}
+
+func (s *sibling) String() string {
+	return s.conn.RemoteAddr().String()
 }
 
 // passFdsToSibling passes all this processes file descriptors to a sibling
 // over the provided unix connection.  It returns an error channel which will,
 // at most, have one error written to it.
-func passFdsToSibling(l log15.Logger, conn *net.UnixConn, passedFiles map[string]*fd) (*sibling, <-chan error) {
-	errChan := make(chan error, 1)
+func (s *sibling) giveFDs(passedFiles map[string]*fd) error {
 	fds := make([]*fd, 0, len(passedFiles))
 	for _, fd := range passedFiles {
 		fds = append(fds, fd)
 	}
 
-	c := &sibling{
-		conn:   conn,
-		readyC: make(chan struct{}),
-		l:      l,
-	}
-	go func() {
-		defer close(errChan)
-		err := c.writeFiles(fds)
-		if err != nil {
-			errChan <- err
-		}
-	}()
-	return c, errChan
-}
-
-// writeFiles passes the list of files to the sibling.
-func (c *sibling) writeFiles(fds []*fd) error {
-	connFile, err := c.conn.File()
+	connFile, err := s.conn.File()
 	if err != nil {
 		return errors.Wrapf(err, "could not convert sibling connection to file")
 	}
+	defer connFile.Close()
+
 	validFds := make([]*fd, 0, len(fds))
 	rawFds := make([]*os.File, 0, len(fds))
 	for i := range fds {
@@ -65,28 +54,11 @@ func (c *sibling) writeFiles(fds []*fd) error {
 		validFds = append(validFds, fd)
 	}
 
-	c.l.Info("passing along fds to our sibling", "files", fds)
-	var jsonBlob bytes.Buffer
-	enc := json.NewEncoder(&jsonBlob)
-	if err := enc.Encode(validFds); err != nil {
-		panic(err)
+	s.l.Info("passing along fds to our sibling", "files", fds)
+	if err := proto.WriteVersionedJSONBlob(s.conn, validFds, proto.Version); err != nil {
+		return fmt.Errorf("error writing json to sibling: %v", err)
 	}
 
-	var jsonBlobLenBuf bytes.Buffer
-	if err := binary.Write(&jsonBlobLenBuf, binary.BigEndian, int32(jsonBlob.Len())); err != nil {
-		panic(fmt.Errorf("could not binary encode an int32: %v", err))
-	}
-	if jsonBlobLenBuf.Len() != 4 {
-		panic(fmt.Errorf("int32 should be 4 bytes, not: %+v", jsonBlobLenBuf))
-	}
-
-	// Length-prefixed json blob
-	if _, err := c.conn.Write(jsonBlobLenBuf.Bytes()); err != nil {
-		return fmt.Errorf("could not write json length to sibling: %v", err)
-	}
-	if _, err := c.conn.Write(jsonBlob.Bytes()); err != nil {
-		return fmt.Errorf("could not write json to sibling: %v", err)
-	}
 	// Write all files it's expecting
 	for _, fi := range rawFds {
 		if err := utils.SendFd(connFile, fi.Name(), fi.Fd()); err != nil {
@@ -94,14 +66,47 @@ func (c *sibling) writeFiles(fds []*fd) error {
 		}
 	}
 
+	return s.awaitReady()
+}
+
+func (s *sibling) awaitReady() error {
 	// Finally, read ready byte and the handoff is done!
 	var b [1]byte
-	if n, err := c.conn.Read(b[:]); n > 0 && b[0] == notifyReady {
-		c.l.Debug("our sibling sent us a ready")
-		c.readyC <- struct{}{}
-	} else {
-		c.l.Debug("our sibling failed to send us a ready", "err", err)
+	n, err := s.conn.Read(b[:])
+	switch {
+	case n > 0 && b[0] == proto.V0NotifyReady:
+		s.l.Debug("our sibling sent us a v0 ready")
+		return nil
+	case n > 0 && b[0] == proto.V1StartReadyHandshake:
+		return s.readyHandshake()
+	default:
+		s.l.Debug("our sibling failed to send us a ready", "err", err)
 		return errors.Wrapf(err, "sibling did not send us a ready byte: read %v bytes, %v", n, b)
+	}
+}
+
+func (s *sibling) readyHandshake() error {
+	var vInfo proto.VersionInformation
+	err := proto.ReadJSONBlob(s.conn, &vInfo)
+	if err != nil {
+		return err
+	}
+	// We told our sibling our version via encoding it in the versioned json blob
+	// of files, so it should speak a version we know. If it doesn't, that mean's
+	// it's a misbehaving client.
+	if vInfo.Version != proto.Version {
+		return fmt.Errorf("unable to transfer ownership: unexpected protocol version: %v", vInfo.Version)
+	}
+	// Send back that we're stepping down, return nil which causes us to step down.
+	err = proto.WriteJSONBlob(s.conn, proto.Message{
+		Msg: proto.V1MessageSteppingDown,
+	})
+	if err != nil {
+		// We can't be totally sure in this case if the new owner received our message or not.
+		// Assume that they did and we should step down, so just log an error and
+		// still return nil to 'happily' step down.
+		// Zero owners is better than two owners.
+		s.l.Error("error sending stepping down message", "err", err)
 	}
 	return nil
 }

--- a/sibling.go
+++ b/sibling.go
@@ -30,8 +30,10 @@ func (s *sibling) String() string {
 }
 
 // passFdsToSibling passes all this processes file descriptors to a sibling
-// over the provided unix connection.  It returns an error channel which will,
-// at most, have one error written to it.
+// over the provided unix connection.  It returns an error if it was unable to
+// pass all file descriptors along, or if the receiver did not signal that they were received.
+// This method also waits for the new process to signal that it intends to take
+// over ownership of those file descriptors.
 func (s *sibling) giveFDs(readyTimeoutC <-chan time.Time, passedFiles map[string]*fd) error {
 	fds := make([]*fd, 0, len(passedFiles))
 	for _, fd := range passedFiles {

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	v1tableroll "github.com/euank/tableroll/v1_0_0"
 	"github.com/inconshreveable/log15"
 	"k8s.io/utils/clock"
 	fakeclock "k8s.io/utils/clock/testing"
@@ -225,7 +226,6 @@ func TestPIDReuse(t *testing.T) {
 // the same listening fds to multiple processes if a 'Ready' is not received in
 // time.
 func TestFdPassMultipleTimes(t *testing.T) {
-	t.Skip("TODO")
 	ctx := context.Background()
 	clock := fakeclock.NewFakeClock(time.Now())
 	coordDir, cleanup := tmpDir()
@@ -333,10 +333,81 @@ func TestUpgradeTimeout(t *testing.T) {
 		t.Fatalf("error creating upgrader: %v", err)
 	}
 	// upg1 serve timeout
-	time.Sleep(60 * time.Millisecond)
+	clock.Step(40 * time.Millisecond)
 	if err := upg2.Ready(); err == nil {
 		t.Fatalf("should not be able to mark as ready after parent timed out")
 	}
+}
+
+// TestUpgradeV0ToUs is basically TestUpgradeHandoff, but with the old server
+// being a v1 tableroll.
+func TestUpgradeV0ToUs(t *testing.T) {
+	ctx := context.Background()
+	coordDir, cleanup := tmpDir()
+	defer cleanup()
+
+	// Copy createTestServer into this function because the v1tableroll and
+	// tableroll have different types, e.g. for options and upg1.Fds, so the old
+	// function can't be made generic trivially by passing in a constructor or
+	// such.
+	upg1, err := v1tableroll.New(ctx, coordDir, v1tableroll.WithLogger(l.New("pid", "1")), v1tableroll.WithUpgradeTimeout(30*time.Millisecond))
+	if err != nil {
+		t.Fatalf("error creating upgrader: %v", err)
+	}
+	defer upg1.Stop()
+	requests1 := make(chan struct{})
+	responses1 := make(chan string)
+	s1 := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests1 <- struct{}{}
+		resp := <-responses1
+		w.Write([]byte(resp))
+	}))
+	defer s1.Close()
+	listen, err := upg1.Fds.Listen(context.Background(), "testListen", nil, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unable to listen: %v", err)
+	}
+	s1.Listener = listen
+	s1.Start()
+	if err := upg1.Ready(); err != nil {
+		t.Fatalf("unable to mark self as ready: %v", err)
+	}
+	c1 := s1.Client()
+	c1t := c1.Transport.(closeIdleTransport)
+
+	go func() {
+		<-requests1
+		responses1 <- "msg1"
+	}()
+	assertResp(t, s1.URL, c1, "msg1")
+	// s1 is listening
+
+	// leave a hanging client connection for s1 before upgrading, then read it after upgrading
+	msg2Response := make(chan struct{})
+	go func() {
+		assertResp(t, s1.URL, c1, "msg2")
+		msg2Response <- struct{}{}
+	}()
+	<-requests1
+
+	// now have s2 take over for s1
+	server2Reqs, server2Msgs, upg2, s2 := createTestServer(t, clock.RealClock{}, 2, coordDir)
+	defer upg2.Stop()
+	defer s2.Close()
+	<-upg1.UpgradeComplete()
+	s1.Listener.Close()
+	// make sure the existing tcp connections aren't re-used anymore
+	c1t.CloseIdleConnections()
+	go func() {
+		<-server2Reqs
+		server2Msgs <- "msg3"
+	}()
+	// Using the client for s1 should work for s2 now since the listener was passed along
+	assertResp(t, s1.URL, c1, "msg3")
+
+	// Hanging server1 request should still be service-able even after s2 has taken over
+	responses1 <- "msg2"
+	<-msg2Response
 }
 
 func assertResp(t *testing.T, url string, c *http.Client, expected string) {

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -347,9 +347,9 @@ func TestUpgradeV0ToUs(t *testing.T) {
 	defer cleanup()
 
 	// Copy createTestServer into this function because the v1tableroll and
-	// tableroll have different types, e.g. for options and upg1.Fds, so the old
-	// function can't be made generic trivially by passing in a constructor or
-	// such.
+	// tableroll packages have different types, e.g. for options and upg1.Fds, so
+	// the old function can't be made generic trivially by passing in a
+	// constructor or such.
 	upg1, err := v1tableroll.New(ctx, coordDir, v1tableroll.WithLogger(l.New("pid", "1")), v1tableroll.WithUpgradeTimeout(30*time.Millisecond))
 	if err != nil {
 		t.Fatalf("error creating upgrader: %v", err)


### PR DESCRIPTION
See the documentation in doc.go and the comment in `transfer_owner.go`'s  `readyHandshake` method for why this protocol change is necessary and what failure modes it has.

This is intended to be a backwards compatible change.

TODO:
- [x] Add a test that uses the previous master of tableroll to do an upgrade handoff with the new one successfully