### PR TITLE
Close listeners in a few more error paths

### DIFF
--- a/fds.go
+++ b/fds.go
@@ -237,10 +237,14 @@ func (f *Fds) ListenWith(id, network, addr string, listenerFunc func(network, ad
 		return nil, err
 	}
 	if _, ok := ln.(Listener); !ok {
+		ln.Close()
 		return nil, errors.Errorf("%T doesn't implement tableroll.Listener", ln)
 	}
-	err = f.addListenerLocked(id, network, addr, ln.(Listener))
-	return ln, err
+	if err := f.addListenerLocked(id, network, addr, ln.(Listener)); err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return ln, nil
 }
 
 // Listener returns an inherited listener with the given ID, or nil.


### PR DESCRIPTION
I've seen evidence that a listener is probably being leaked somewhere, and these are all the spots I found a missing close...

I'm not confident that the problem is actually here vs the application using the library, but these changes do seem right.