### PR TITLE
Avoid setting file descriptors to 'blocking' mode as a side effect of transfering them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,4 @@ jobs:
     - run:
         name: Run unit tests
         command: |
-          go mod vendor
           go test -race ./...

--- a/cmsg.go
+++ b/cmsg.go
@@ -1,0 +1,80 @@
+package tableroll
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// This file is partilaly based on
+// https://github.com/opencontainers/runc/blob/cf6c074115d00c932ef01dedb3e13ba8b8f964c3/libcontainer/utils/cmsg.go,
+// used under the terms of the apache license, 2.0.
+
+// oobSpace is the size of the oob slice required to store a single FD. Note
+// that unix.UnixRights appears to make the assumption that fd is always int32,
+// so sizeof(fd) = 4.
+var oobSpace = unix.CmsgSpace(4)
+
+const maxNameLen = 4096
+
+// recvFile receives a '*file' object from a socket that was send using
+// 'sendFile'.
+// It's identical to the RecvFd call taken from libcontainer, other than
+// returning the '*file' type instead of an '*os.File' type.
+// This is important because the RecvFd, in returning a '*os.File', requires us
+// to call '.Fd()' to get back the underlying file descriptor, which has a
+// side-effect of putting the fd into blocking mode.
+// We'd rather keep a reference to the fd in our own '*file' struct so we can
+// avoid that.
+func recvFile(socket *os.File) (*file, error) {
+	name := make([]byte, maxNameLen)
+	oob := make([]byte, oobSpace)
+
+	sockfd := socket.Fd()
+	n, oobn, _, _, err := unix.Recvmsg(int(sockfd), name, oob, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if n >= maxNameLen || oobn != oobSpace {
+		return nil, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
+	}
+
+	// Truncate.
+	name = name[:n]
+	oob = oob[:oobn]
+
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+	if len(scms) != 1 {
+		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
+	}
+	scm := scms[0]
+
+	fds, err := unix.ParseUnixRights(&scm)
+	if err != nil {
+		return nil, err
+	}
+	if len(fds) != 1 {
+		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
+	}
+	fd := uintptr(fds[0])
+	fi := newFile(fd, string(name))
+	if fi == nil {
+		return nil, fmt.Errorf("could not construct a file")
+	}
+	return fi, nil
+}
+
+// sendFile sends a *file's file descriptor and name over the given socket.
+func sendFile(socket *os.File, fi *file) error {
+	name := fi.Name()
+	if len(name) >= maxNameLen {
+		return fmt.Errorf("sendfd: filename too long: %s", fi.Name())
+	}
+	oob := unix.UnixRights(int(fi.fd))
+	return unix.Sendmsg(int(socket.Fd()), []byte(name), oob, nil, 0)
+}

--- a/cmsg.go
+++ b/cmsg.go
@@ -1,15 +1,31 @@
 package tableroll
 
+// Taken from
+// https://github.com/opencontainers/runc/blob/cf6c074115d00c932ef01dedb3e13ba8b8f964c3/libcontainer/utils/cmsg.go,
+// and modified under the terms of the apache license, 2.0.
+
+/*
+ * Copyright 2016, 2017 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import (
 	"fmt"
 	"os"
 
 	"golang.org/x/sys/unix"
 )
-
-// This file is partilaly based on
-// https://github.com/opencontainers/runc/blob/cf6c074115d00c932ef01dedb3e13ba8b8f964c3/libcontainer/utils/cmsg.go,
-// used under the terms of the apache license, 2.0.
 
 // oobSpace is the size of the oob slice required to store a single FD. Note
 // that unix.UnixRights appears to make the assumption that fd is always int32,

--- a/fds.go
+++ b/fds.go
@@ -61,7 +61,11 @@ type file struct {
 }
 
 func (f *file) String() string {
-	return fmt.Sprintf("File(name=%q,fd=%v)", f.Name(), f.fd)
+	name := "<nil>"
+	if f != nil && f.File != nil {
+		name = f.Name()
+	}
+	return fmt.Sprintf("File(name=%q,fd=%v)", name, f.fd)
 }
 
 func newFile(fd uintptr, name string) *file {
@@ -88,9 +92,6 @@ type fd struct {
 	// ID is the id of this file, stored just for pretty-printing
 	ID string `json:"id"`
 
-	// for files, stored just for pretty-printing
-	Name string `json:"name,omitEmpty"`
-
 	// for conns/listeners, stored just for pretty-printing
 	Network string `json:"network,omitEmpty"`
 	Addr    string `json:"addr,omitEmpty"`
@@ -99,7 +100,7 @@ type fd struct {
 func (f *fd) String() string {
 	switch f.Kind {
 	case fdKindFile:
-		return fmt.Sprintf("file(%v): %v", f.ID, f.Name)
+		return fmt.Sprintf("file(%v)", f.ID)
 	case fdKindListener:
 		return fmt.Sprintf("listener(%v): %v:%v", f.ID, f.Network, f.Addr)
 	case fdKindConn:
@@ -381,7 +382,6 @@ func (f *Fds) OpenFileWith(id string, name string, openFunc func(name string) (*
 
 	newFd := &fd{
 		ID:   id,
-		Name: name,
 		Kind: fdKindFile,
 		file: dup,
 	}

--- a/fds.go
+++ b/fds.go
@@ -182,7 +182,7 @@ func (f *Fds) Listen(ctx context.Context, id string, cfg *net.ListenConfig, netw
 		return nil, err
 	}
 	if ln != nil {
-		f.l.Debug("found existing listener in store", "network", network, "addr", addr)
+		f.l.Debug("found existing listener in store", "listenerId", id, "network", network, "addr", addr)
 		return ln, nil
 	}
 

--- a/fds.go
+++ b/fds.go
@@ -96,14 +96,6 @@ type fd struct {
 	Addr    string `json:"addr,omitEmpty"`
 }
 
-func (f *fd) associateFile(name string, osFile *os.File) {
-	f.file = &file{
-		osFile,
-		osFile.Fd(),
-	}
-	f.Name = name
-}
-
 func (f *fd) String() string {
 	switch f.Kind {
 	case fdKindFile:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/opencontainers/runc v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.8.1
-	github.com/rkt/rkt v1.30.0
+	github.com/rkt/rkt v1.30.0 // indirect
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20201101102859-da207088b7d1
 	k8s.io/utils v0.0.0-20190221042446-c2654d5206da
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/euank/filelock v0.0.0-20200318073246-6ea232a62104 h1:ZWa+OP7bAv6VzHk4TGs8tAgqjiwPX0MHpy91RU2EwBk=
 github.com/euank/filelock v0.0.0-20200318073246-6ea232a62104/go.mod h1:ru909esF20lQaIexNrnNvUglS/iVrZzYnt6EsPxyWP8=
 github.com/euank/tableroll v1.0.1-0.20190509205925-1c7855724129 h1:oDXWZeVpyOpwiT/4qTGcG1kLEYMIzEhQcobFJNk/q6Y=
@@ -16,11 +18,21 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rkt/rkt v1.30.0 h1:ZI5RQtSibfjicSttV/HLiHuWreYClEJA2Or5XKAdJb0=
 github.com/rkt/rkt v1.30.0/go.mod h1:V5VwmwHe6x1kflB4uXl1XJwXTgRISEMt2lZE6m6lXd0=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1 h1:a/mKvvZr9Jcc8oKfcmgzyp7OwF73JPWsQLvH1z2Kxck=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da h1:ElyM7RPonbKnQqOcw7dG2IK5uvQQn3b/WPHqD5mBvP4=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=

--- a/sibling.go
+++ b/sibling.go
@@ -77,12 +77,7 @@ func (s *sibling) giveFDs(readyTimeoutC <-chan time.Time, passedFiles map[string
 
 	// Write all files it's expecting
 	for _, fi := range validFds {
-		// dup the file we're sending since we'll eventually close 'fi.file'
-		dup, err := dupFd(fi.file.fd, fi.file.Name())
-		if err != nil {
-			return fmt.Errorf("could not write fds to sibling: %v", err)
-		}
-		if err := sendFile(connFile, dup); err != nil {
+		if err := sendFile(connFile, fi.file); err != nil {
 			return fmt.Errorf("could not write fds to sibling: %v", err)
 		}
 	}

--- a/sibling.go
+++ b/sibling.go
@@ -78,7 +78,7 @@ func (s *sibling) giveFDs(readyTimeoutC <-chan time.Time, passedFiles map[string
 	// Write all files it's expecting
 	for _, fi := range validFds {
 		// dup the file we're sending since we'll eventually close 'fi.file'
-		dup, err := dupFd(fi.file.fd, fi.Name)
+		dup, err := dupFd(fi.file.fd, fi.file.Name())
 		if err != nil {
 			return fmt.Errorf("could not write fds to sibling: %v", err)
 		}

--- a/transfer_owner.go
+++ b/transfer_owner.go
@@ -126,7 +126,6 @@ func (s *upgradeSession) getFiles(ctx context.Context) (map[string]*fd, error) {
 	for i := range fds {
 		fd := fds[i]
 		fd.file = sockFiles[i]
-		fd.Name = fd.file.Name()
 		files[fd.ID] = fd
 	}
 	s.l.Info("got fds from old owner", "files", files)

--- a/transfer_owner.go
+++ b/transfer_owner.go
@@ -117,6 +117,7 @@ func (s *upgradeSession) getFiles(ctx context.Context) (map[string]*fd, error) {
 	for i := 0; i < len(sockFileNames); i++ {
 		file, err := utils.RecvFd(sockFile)
 		if err != nil {
+			s.l.Error("error receiving a file descriptor", "err", err)
 			return nil, orContextErr(errors.Wrap(err, "error getting file descriptors"))
 		}
 		sockFiles = append(sockFiles, file)

--- a/upgrader_process_test.go
+++ b/upgrader_process_test.go
@@ -223,7 +223,7 @@ func TestMaxSocketUpg(t *testing.T) {
 	tmpdir, cleanup := tmpDir()
 	defer cleanup()
 
-	stdout, errC, exitC1 := runHelper(t, ctx, tmpdir, "maxSocketOpener", "")
+	stdout, errC, exitC1 := runHelper(t, ctx, tmpdir, "listenOnManySockets", "")
 	select {
 	case msg := <-stdout:
 		if msg != MsgReady {
@@ -235,7 +235,7 @@ func TestMaxSocketUpg(t *testing.T) {
 		t.Fatalf("unexpected exit: %v", exit)
 	}
 
-	stdout, errC, exitC := runHelper(t, ctx, tmpdir, "maxSocketOpener", "")
+	stdout, errC, exitC := runHelper(t, ctx, tmpdir, "listenOnManySockets", "")
 	select {
 	case msg := <-stdout:
 		if msg != MsgReady {
@@ -320,8 +320,8 @@ func TestSpawnHelper(t *testing.T) {
 		os.Exit(main1())
 	case "main2":
 		os.Exit(main2())
-	case "maxSocketOpener":
-		os.Exit(maxSocketOpener())
+	case "listenOnManySockets":
+		os.Exit(listenOnManySockets())
 	default:
 		fmt.Fprintf(os.Stderr, "unknown main function: %v", funcName)
 		os.Exit(1)
@@ -402,7 +402,12 @@ func main2() int {
 	return 0
 }
 
-func maxSocketOpener() int {
+// listenOnManySockets is a regression test for when we transferred all fds in
+// a single sendmsg call, which hit a limit somewhere around 300 or 400 FDs.
+// We now do 1 at a time, which should support many many more.
+// However, this test still limits itself to 800 sockets opened to avoid
+// running afoul of small ulimits, which are expected to cause issues.
+func listenOnManySockets() int {
 	ctx := context.Background()
 	tableRollDir := os.Getenv("TABLEROLL_DIR")
 
@@ -417,13 +422,10 @@ func maxSocketOpener() int {
 		return 1
 	}
 
-	// Assume we can always open at least 500, ulimits are usually around 1024
-	// and 500 is enough to catch the regression this is testing for.
-	minFds := 500
 	lns := []net.Listener{}
 	ids := []string{}
 	var i int
-	for i = 0; err == nil; i++ {
+	for i = 0; i < 600; i++ {
 		id := fmt.Sprintf("ln-%v", i)
 		ln, err := upg.Fds.ListenWith(id, "tcp", "127.0.0.1:0", net.Listen)
 		if err != nil {
@@ -432,12 +434,7 @@ func maxSocketOpener() int {
 		lns = append(lns, ln)
 		ids = append(ids, id)
 	}
-	if i < minFds {
-		fmt.Fprintf(os.Stderr, "could not open %v fds, only opened %v: %v", minFds, i+1, err)
-		return 1
-	}
 
-	// Close the last 10 to free up enough fds for the upgrade to happen
 	lns, toClose := lns[0:len(lns)-10], lns[len(lns)-10:]
 	for _, ln := range toClose {
 		ln.Close()

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -445,7 +445,7 @@ func TestFailedUpgradeListen(t *testing.T) {
 	// Accept, then Close
 	go func() {
 		_, err := ln.Accept()
-		require.Contains(t, "use of a closed network connection", err.Error())
+		require.Contains(t, err.Error(), "use of closed network connection")
 	}()
 	// let the accept happen first
 	time.Sleep(1 * time.Millisecond)

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +15,7 @@ import (
 
 	v1tableroll "github.com/euank/tableroll/v1_0_0"
 	"github.com/inconshreveable/log15"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/clock"
 	fakeclock "k8s.io/utils/clock/testing"
 )
@@ -418,6 +420,38 @@ func TestUpgradeV0ToUs(t *testing.T) {
 	// Hanging server1 request should still be service-able even after s2 has taken over
 	responses1 <- "msg2"
 	<-msg2Response
+}
+
+// TestFTestFailedUpgradeAccept tests that 'ln.Accept' works for a listener
+// correctly after a failed upgrade. This is a regression test for a bug that
+// left file descriptors in 'blocking' mode, which resulted in accept + close
+// deadlocking.
+func TestFailedUpgradeListen(t *testing.T) {
+	ctx := context.Background()
+	coordDir, cleanup := tmpDir()
+	defer cleanup()
+
+	upg1, err := newUpgrader(ctx, clock.RealClock{}, coordDir, "1", WithLogger(l.New("pid", "1")))
+	require.Nil(t, err)
+	ln, err := upg1.Fds.Listen(ctx, "id", &net.ListenConfig{}, "tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	upg1.Ready()
+
+	// fail an upgrade
+	upg2, err := newUpgrader(ctx, clock.RealClock{}, coordDir, "2", WithLogger(l.New("pid", "2")))
+	require.Nil(t, err)
+	upg2.Stop()
+
+	// Accept, then Close
+	go func() {
+		_, err := ln.Accept()
+		require.Contains(t, "use of a closed network connection", err.Error())
+	}()
+	// let the accept happen first
+	time.Sleep(1 * time.Millisecond)
+	err = ln.Close()
+	require.Nil(t, err)
+	// if we aren't deadlocked here, the regression test passes
 }
 
 func assertResp(t *testing.T, url string, c *http.Client, expected string) {


### PR DESCRIPTION
This fixes a deadlock that it was possible to get into while transfering files.

The included test shows how this deadlock can be triggered.

Effectively, there's a window during a tableroll upgrade where file descriptors are set to blocking (without the go runtime realizing it due to `fcntl(F_SET)` operating on an fd's file description, and go basing its internal blocking/nonblocking flag on a descriptor, not description). During a successful upgrade, file descriptors are then set back to nonblocking when they're `Fds.Listen`'d on. However, in a failed upgrade, they're left in this bad state for an extended period, and the go runtime can deadlock itself.

This fixes that issue by vendoring in the tiny bit of `runc/libcontainer` we were using to send Fds, and changing the interface to allow us to avoid setting Fds to blocking. See the commit message for an additional description of that.