### PR TITLE
Release v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok/tableroll
+module github.com/ngrok/tableroll/v2
 
 require (
 	github.com/euank/filelock v0.0.0-20200318073246-6ea232a62104


### PR DESCRIPTION
Switching to taking an identifier as an argument instead of using the
process's pid is a breaking change, so we should tag it as such.