### PR TITLE
Close all old file descriptors on update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok-oss/tableroll/v2"
+	"github.com/ngrok-oss/tableroll/v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok-oss/tableroll/v2
+module github.com/ngrok-oss/tableroll/v3
 
 require (
 	github.com/euank/filelock v0.0.0-20200318073246-6ea232a62104

--- a/sibling.go
+++ b/sibling.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok-oss/tableroll/v2/internal/proto"
+	"github.com/ngrok-oss/tableroll/v3/internal/proto"
 	"github.com/pkg/errors"
 )
 

--- a/transfer_owner.go
+++ b/transfer_owner.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok-oss/tableroll/v2/internal/proto"
+	"github.com/ngrok-oss/tableroll/v3/internal/proto"
 	"github.com/pkg/errors"
 )
 

--- a/upgrader.go
+++ b/upgrader.go
@@ -238,6 +238,12 @@ func (u *Upgrader) Ready() error {
 	if err := u.state.transitionTo(upgraderStateOwner); err != nil {
 		return err
 	}
+
+	// Now cleanup all old FDs while holding the lock
+	u.Fds.lockMutations(errors.New("closing old listeners"))
+	defer u.Fds.unlockMutations()
+	_ = u.Fds.closeUnused()
+
 	return nil
 }
 


### PR DESCRIPTION
This changes it so we track used/unused FDs, and then after an upgrade succeeds, we can close all the ones that we haven't seen used.

This does mean that it's expected the user start listening on all the FDs again before marking the upgrade complete, but that was also the only safe way to do it before which wouldn't leak an FD, so I think that's true.

This is intended as an anti-fd-leakage measure, and I think is safe if you're using the library right.
The existing tests all seem happy at least!

Anyway, marking it as draft for now while I do additional testing.