### PR TITLE
Hotfix panic during `closeUnused`

### DIFF
--- a/fds.go
+++ b/fds.go
@@ -131,9 +131,10 @@ type Fds struct {
 	l log15.Logger
 }
 
-func (f *Fds) String() string {
-	res := make([]string, 0, len(f.fds))
-	for _, fi := range f.fds {
+func (f *Fds) String() string { // XXX here?
+	fds := f.copy()
+	res := make([]string, 0, len(fds))
+	for _, fi := range fds {
 		res = append(res, fi.String())
 	}
 	return fmt.Sprintf("fds: %v", res)

--- a/upgrader.go
+++ b/upgrader.go
@@ -240,9 +240,9 @@ func (u *Upgrader) Ready() error {
 	}
 
 	// Now cleanup all old FDs while holding the lock
-	u.Fds.lockMutations(errors.New("closing old listeners"))
-	defer u.Fds.unlockMutations()
-	_ = u.Fds.closeUnused()
+	//u.Fds.lockMutations(errors.New("closing old listeners"))
+	// defer u.Fds.unlockMutations()
+	//_ = u.Fds.closeUnused()
 
 	return nil
 }


### PR DESCRIPTION
We're seeing concurrent map read/write in `closeUnused`. this is a quick fix to remove the problem; we'll diagnose further later.