### PR TITLE
Correctly lock fds when closing old listeners

### DIFF
--- a/upgrader.go
+++ b/upgrader.go
@@ -240,9 +240,9 @@ func (u *Upgrader) Ready() error {
 	}
 
 	// Now cleanup all old FDs while holding the lock
-	//u.Fds.lockMutations(errors.New("closing old listeners"))
-	// defer u.Fds.unlockMutations()
-	//_ = u.Fds.closeUnused()
+	u.Fds.lockMutations(ErrClosingListeners)
+	defer u.Fds.unlockMutations()
+	_ = u.Fds.closeUnused()
 
 	return nil
 }


### PR DESCRIPTION
`mu` is used to protect all reads and writes of the `fds` map in `Fds`.

`closeUnused` is writing to the map, and so needs a lock. Oops :(

The confusing naming of 'lockMutations' made me think this was a leaky abstraction that held the lock between function calls, but it's not that, it's just setting an informational message and 'locked' boolean (also protected by 'mu'), 'mu' itself still needs to be held.

The naming of those methods is clearly confusing since it confused me, but making more drastic changes seems like it's best left to another PR.