### PR TITLE
fix: race condition closing upgradeCompleteC channel

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,4 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.2.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.0/direnvrc" "sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc="
 fi
 dotenv_if_exists
-GOPATH=`pwd`/.direnv/go
-PATH=${GOPATH}/bin:${PATH}
 use flake

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,13 +20,8 @@ jobs:
       - uses: HatsuneMiku3939/direnv-action@68bdc19f46a32f049a01c2ea233fe7ca017e8840 # v1
       - name: direnv allow
         run: direnv allow .
-      - name: Run goimports
-        shell: bash
-        run: |
-          shopt -s globstar
-          direnv exec . goimports -format-only -w -local github.com/ngrok-oss/tableroll **/*.go
       - name: Lint
-        run: direnv exec . golangci-lint run .
+        run: direnv exec . make lint
       - name: Check diff
         shell: bash
         run: git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
     - name: direnv allow
       run: direnv allow .
     - name: Test
-      run: direnv exec . make test-race COUNT=100
+      run: direnv exec . make test-race COUNT=20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
     - name: direnv allow
       run: direnv allow .
     - name: Test
-      run: direnv exec . go test -v ./...
+      run: direnv exec . make test-race COUNT=100

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: test test-race test-stress lint
+
+COUNT ?= 1
+
+# Run tests
+# Usage:
+#   make test          # default 1 iteration
+#   make test COUNT=50 # custom iteration count
+test:
+	go test -v -count=$(COUNT) ./...
+
+# Run tests with race detector
+# Usage:
+#   make test-race            # default 1 iteration
+#   make test-race COUNT=100  # custom iteration count
+test-race:
+	go test -v -race -count=$(COUNT) ./...
+
+# Run goimports and golangci-lint
+lint:
+	goimports -format-only -w -local github.com/ngrok-oss/tableroll .
+	golangci-lint run ./...

--- a/coordinator_test.go
+++ b/coordinator_test.go
@@ -54,7 +54,7 @@ func TestConnectOwner(t *testing.T) {
 // canceled by canceling the passed in context.
 func TestLockCoordinationDirCtxCancel(t *testing.T) {
 	l := slog.Default()
-	ctx := testCtx(t)
+	ctx := t.Context()
 	tmpdir := tmpDir(t)
 	coord1 := newCoordinator(clock.RealClock{}, l, tmpdir, "1")
 	coord2 := newCoordinator(clock.RealClock{}, l, tmpdir, "2")

--- a/upgrader.go
+++ b/upgrader.go
@@ -35,6 +35,7 @@ type Upgrader struct {
 	// is no longer the owner of its Fds.
 	// This also occurs when `Stop` is called.
 	upgradeCompleteC chan struct{}
+	closeUpgradeOnce sync.Once
 
 	l *slog.Logger
 
@@ -201,7 +202,7 @@ func (u *Upgrader) handleUpgradeRequest(conn *net.UnixConn) {
 	// don't care.
 	u.Fds.lockMutations(ErrUpgradeCompleted)
 	_ = u.transitionTo(upgraderStateDraining)
-	close(u.upgradeCompleteC)
+	u.closeUpgradeComplete()
 }
 
 // Ready signals that the current process is ready to accept connections.
@@ -246,6 +247,15 @@ func (u *Upgrader) Ready() error {
 	return nil
 }
 
+// closeUpgradeComplete safely closes the upgradeCompleteC channel exactly once.
+// This is needed because both handleUpgradeRequest and Stop can close the
+// channel, and without synchronization this races.
+func (u *Upgrader) closeUpgradeComplete() {
+	u.closeUpgradeOnce.Do(func() {
+		close(u.upgradeCompleteC)
+	})
+}
+
 // UpgradeComplete returns a channel which is closed when the managed file
 // descriptors have been passed to the next process, and the next process has
 // indicated it is ready.
@@ -265,10 +275,6 @@ func (u *Upgrader) Stop() {
 		// Interrupt any running Upgrade(), and
 		// prevent new upgrade from happening.
 		_ = u.upgradeSock.Close()
-		select {
-		case <-u.upgradeCompleteC:
-		default:
-			close(u.upgradeCompleteC)
-		}
+		u.closeUpgradeComplete()
 	})
 }

--- a/upgrader_process_test.go
+++ b/upgrader_process_test.go
@@ -170,9 +170,15 @@ func TestUnixMultiProcessUpgrade(t *testing.T) {
 		stdoutn, errCn, exitCn := runHelper(ctx, tmpdir, "main2", "")
 
 		// process n-1 should exit
-		exit := <-prevExit
-		if exit != 0 {
-			t.Fatalf("expected 0 exit: %v", exit)
+		select {
+		case exit := <-prevExit:
+			if exit != 0 {
+				t.Fatalf("expected 0 exit: %v", exit)
+			}
+		case err := <-errCn:
+			t.Fatalf("unexpected err from new process: %v", err)
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for previous process to exit")
 		}
 
 		// process 2 should be ready
@@ -271,7 +277,7 @@ func runHelper(ctx context.Context, dir string, funcName string, addr string) (<
 	}...)
 
 	stdoutChan := make(chan string, 1)
-	errorChan := make(chan error, 1)
+	errorChan := make(chan error, 3)
 	exitChan := make(chan int, 1)
 
 	stdoutScanner := bufio.NewScanner(stdout)
@@ -294,8 +300,14 @@ func runHelper(ctx context.Context, dir string, funcName string, addr string) (<
 		}
 		if err != nil {
 			errorChan <- err
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitChan <- exitErr.ExitCode()
+			} else {
+				exitChan <- 1
+			}
+		} else {
+			exitChan <- 0
 		}
-		exitChan <- 0
 		close(exitChan)
 	}()
 

--- a/upgrader_process_test.go
+++ b/upgrader_process_test.go
@@ -32,7 +32,7 @@ func loopbackTCPAddr(t *testing.T) string {
 }
 
 func TestBasicProcessUpgrade(t *testing.T) {
-	ctx := testCtx(t)
+	ctx := t.Context()
 	tmpdir := tmpDir(t)
 
 	testAddr := loopbackTCPAddr(t)
@@ -125,7 +125,7 @@ func TestBasicProcessUpgrade(t *testing.T) {
 }
 
 func TestUnixMultiProcessUpgrade(t *testing.T) {
-	ctx := testCtx(t)
+	ctx := t.Context()
 	tmpdir := tmpDir(t)
 
 	sock := filepath.Join(tmpdir, "testsock")

--- a/upgrader_test.go
+++ b/upgrader_test.go
@@ -301,10 +301,12 @@ func TestUpgradeTimeout(t *testing.T) {
 	// If upg1 times out serving the upgrade, upg2 should not be able to think it's the owner
 	upg1, err := newUpgrader(ctx, clock, coordDir, "1", WithLogger(l.With("pid", "1")), WithUpgradeTimeout(30*time.Millisecond))
 	require.NoError(t, err)
+	defer upg1.Stop()
 	require.NoError(t, upg1.Ready())
 
 	upg2, err := newUpgrader(ctx, clock, coordDir, "2", WithLogger(l.With("pid", "2")))
 	require.NoError(t, err)
+	defer upg2.Stop()
 	// upg1 serve timeout
 	for !clock.HasWaiters() {
 		time.Sleep(1 * time.Millisecond)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,7 +1,6 @@
 package tableroll
 
 import (
-	"context"
 	"os"
 	"testing"
 )
@@ -15,10 +14,4 @@ func tmpDir(t *testing.T) string {
 		_ = os.RemoveAll(dir)
 	})
 	return dir
-}
-
-func testCtx(t *testing.T) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	return ctx
 }


### PR DESCRIPTION
### Summary
- Fix a pre-existing race condition where both `handleUpgradeRequest` and `Stop` could close the `upgradeCompleteC` channel concurrently, causing a `panic: close of closed channel`
- Add a `Makefile` with `test`, `test-race`, and `lint` targets and update CI workflows to use them
- Run tests with `-race -count=20` in CI to catch flaky races before merge

### Details

The `upgradeCompleteC` channel can be closed from two codepaths:

1. `handleUpgradeRequest` — after a successful upgrade handoff
2. `Stop` — when shutting down the upgrader

The `select` guard in `Stop` was not atomic with the `close`, so if `handleUpgradeRequest` transitioned to `Draining` but hadn't yet closed the channel, `Stop` could race in and close it first. The subsequent close in `handleUpgradeRequest` would then panic.

The fix uses a `sync.Once` to ensure the channel is closed exactly once regardless of which codepath reaches it first. `TestUpgradeTimeout` also now properly cleans up upgraders with `defer Stop()` to prevent goroutine leaks.

### Other

There were also some other issues with the tests helpers and other things we changed:
* Updated to use `t.Context()`
* Update test channel helper to allow for multiple sends. The size of 1 was too small.
* Correctly propagating error from tests instead of sending 0
* Use context aware select instead of just looking at prevExit